### PR TITLE
Marked IEnumForm as transient in MixinPokemonBase.java

### DIFF
--- a/src/main/java/com/envyful/mixins/reforged/MixinPokemonBase.java
+++ b/src/main/java/com/envyful/mixins/reforged/MixinPokemonBase.java
@@ -16,7 +16,7 @@ public abstract class MixinPokemonBase implements ITranslatable {
 
     @Shadow public abstract EnumSpecies getSpecies();
 
-    private IEnumForm formCache = null;
+    private transient IEnumForm formCache = null;
 
     @Inject(method = "getFormEnum", at = @At("RETURN"), remap = false)
     public void onGetFormEnumRETURN(CallbackInfoReturnable<IEnumForm> cir) {


### PR DESCRIPTION
Because Interfaces cannot be directly instantiated, they should be marked as transient to prevent serialization issues. 